### PR TITLE
CalendarPage 구현

### DIFF
--- a/src/data/calendarData.json
+++ b/src/data/calendarData.json
@@ -1,0 +1,30 @@
+[
+  {
+    "date": 1,
+    "workoutColors": ["#EF4444", "#3B82F6", "#EAB308"]
+  },
+  {
+    "date": 3,
+    "workoutColors": ["#1E40AF", "#22C55E"]
+  },
+  {
+    "date": 7,
+    "workoutColors": ["#22C55E", "#EAB308", "#1E40AF"]
+  },
+  {
+    "date": 9,
+    "workoutColors": ["#1E40AF"]
+  },
+  {
+    "date": 14,
+    "workoutColors": ["#EAB308"]
+  },
+  {
+    "date": 17,
+    "workoutColors": ["#3B82F6", "#22C55E", "#EF4444"]
+  },
+  {
+    "date": 29,
+    "workoutColors": ["#3B82F6", "#16A34A", "#EAB308", "#8B5CF6", "#EC4899", "#F97316", "#EF4444", "#1E40AF", "#22C55E", "#7C3AED"]
+  }
+]

--- a/src/data/memberColors.json
+++ b/src/data/memberColors.json
@@ -1,0 +1,38 @@
+[
+  {
+    "color": "#8B5CF6",
+    "nickname": "엄복동"
+  },
+  {
+    "color": "#22C55E",
+    "nickname": "하루종일 달러"
+  },
+  {
+    "color": "#EAB308",
+    "nickname": "달려라 하니"
+  },
+  {
+    "color": "#EC4899",
+    "nickname": "콜먼 Park"
+  },
+  {
+    "color": "#3B82F6",
+    "nickname": "철수책상철책상"
+  },
+  {
+    "color": "#EF4444",
+    "nickname": "강감찬감강"
+  },
+  {
+    "color": "#F97316",
+    "nickname": "haryahah"
+  },
+  {
+    "color": "#1E40AF",
+    "nickname": "콤부차"
+  },
+  {
+    "color": "#16A34A",
+    "nickname": "대한건아"
+  }
+]

--- a/src/pages/meeting/CalendarPage.tsx
+++ b/src/pages/meeting/CalendarPage.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-const CalendarPage: React.FC = () => <div>캘린더 화면</div>;
-
-export default CalendarPage; 

--- a/src/pages/meeting/calendar/CalendarPage.tsx
+++ b/src/pages/meeting/calendar/CalendarPage.tsx
@@ -1,0 +1,72 @@
+import React, { useState, useEffect } from 'react';
+import Calendar from './components/Calendar';
+import type { CalendarDayData, MemberColor } from '../../../types/meeting';
+import memberColorsDataJson from '../../../data/memberColors.json';
+import calendarDataJson from '../../../data/calendarData.json';
+
+const CalendarPage: React.FC = () => {
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [calendarData, setCalendarData] = useState<CalendarDayData[]>([]);
+  const [memberColors, setMemberColors] = useState<MemberColor[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    // 실제 API 호출로 교체 예정
+    const fetchCalendarData = async () => {
+      try {
+        // TODO: 실제 API 호출로 교체
+        // const response = await fetch(`/api/meetings/${meetingId}/calendar?year=${currentDate.getFullYear()}&month=${currentDate.getMonth() + 1}`);
+        // const data = await response.json();
+        
+        // 현재는 정적 데이터 사용
+        setCalendarData(calendarDataJson);
+        setMemberColors(memberColorsDataJson);
+      } catch (error) {
+        console.error('Failed to fetch calendar data:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchCalendarData();
+  }, [currentDate]);
+
+  const handlePrevMonth = () => {
+    setCurrentDate(prev => {
+      const newDate = new Date(prev);
+      newDate.setMonth(prev.getMonth() - 1);
+      return newDate;
+    });
+  };
+
+  const handleNextMonth = () => {
+    setCurrentDate(prev => {
+      const newDate = new Date(prev);
+      newDate.setMonth(prev.getMonth() + 1);
+      return newDate;
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-gray-500">달력을 불러오는 중...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full flex flex-col p-4">
+      <Calendar
+        year={currentDate.getFullYear()}
+        month={currentDate.getMonth() + 1}
+        calendarData={calendarData}
+        memberColors={memberColors}
+        onPrevMonth={handlePrevMonth}
+        onNextMonth={handleNextMonth}
+      />
+    </div>
+  );
+};
+
+export default CalendarPage;

--- a/src/pages/meeting/calendar/components/Calendar.tsx
+++ b/src/pages/meeting/calendar/components/Calendar.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import CalendarHeader from './CalendarHeader';
+import CalendarGrid from './CalendarGrid';
+import MemberLegend from './MemberLegend';
+import type { CalendarDayData, MemberColor } from '../../../../types/meeting';
+
+interface CalendarProps {
+  year: number;
+  month: number;
+  calendarData: CalendarDayData[];
+  memberColors: MemberColor[];
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+}
+
+const Calendar: React.FC<CalendarProps> = ({
+  year,
+  month,
+  calendarData,
+  memberColors,
+  onPrevMonth,
+  onNextMonth
+}) => {
+  return (
+    <div className="w-full h-full flex flex-col p-4 overflow-y-auto scrollbar-hide">
+      {/* 달력 헤더 */}
+      <CalendarHeader
+        year={year}
+        month={month}
+        onPrevMonth={onPrevMonth}
+        onNextMonth={onNextMonth}
+      />
+      
+      {/* 달력 그리드 */}
+      <div className="mt-4">
+        <CalendarGrid
+          year={year}
+          month={month}
+          calendarData={calendarData}
+        />
+      </div>
+      
+      {/* 멤버 범례 */}
+      <div className="mt-4 pb-4">
+        <MemberLegend memberColors={memberColors} />
+      </div>
+    </div>
+  );
+};
+
+export default Calendar;

--- a/src/pages/meeting/calendar/components/CalendarDay.tsx
+++ b/src/pages/meeting/calendar/components/CalendarDay.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import WorkoutDot from './WorkoutDot';
+
+interface CalendarDayProps {
+  date: number;
+  isCurrentMonth: boolean;
+  workoutColors: string[];
+}
+
+const CalendarDay: React.FC<CalendarDayProps> = ({
+  date,
+  isCurrentMonth,
+  workoutColors
+}) => {
+  console.log(`CalendarDay ${date}:`, { isCurrentMonth, workoutColors }); // 디버깅용
+  
+  return (
+    <div className={`min-h-[50px] border-r border-b border-gray-200 flex flex-col items-center justify-start p-1 ${
+      isCurrentMonth ? 'text-black bg-white' : 'text-gray-300 bg-gray-50'
+    }`}>
+      {/* 날짜 */}
+      <div className={`text-xs font-bold mb-1 ${
+        isCurrentMonth ? 'text-black' : 'text-gray-400'
+      }`}>
+        {date}
+      </div>
+      
+      {/* 운동 기록 점들 */}
+      {workoutColors.length > 0 && (
+        <div className="w-full h-7 overflow-y-auto scrollbar-hide">
+          <div className="grid grid-cols-3 gap-1 justify-items-center">
+            {workoutColors.map((color, index) => (
+              <WorkoutDot key={index} color={color} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CalendarDay;

--- a/src/pages/meeting/calendar/components/CalendarGrid.tsx
+++ b/src/pages/meeting/calendar/components/CalendarGrid.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import CalendarDay from './CalendarDay';
+import type { CalendarDayData } from '../../../../types/meeting';
+
+interface CalendarGridProps {
+  year: number;
+  month: number;
+  calendarData: CalendarDayData[];
+}
+
+const CalendarGrid: React.FC<CalendarGridProps> = ({
+  year,
+  month,
+  calendarData
+}) => {
+  // 해당 월의 첫 번째 날과 마지막 날 계산
+  const firstDay = new Date(year, month - 1, 1);
+  const lastDay = new Date(year, month, 0);
+  
+  // 첫 번째 날의 요일 (0: 일요일, 1: 월요일, ...)
+  const firstDayOfWeek = firstDay.getDay();
+  
+  // 이전 달의 마지막 날들
+  const prevMonthLastDay = new Date(year, month - 1, 0).getDate();
+  
+  // 달력에 표시할 모든 날짜 배열 생성
+  const calendarDays: Array<{
+    date: number;
+    isCurrentMonth: boolean;
+    workoutColors: string[];
+  }> = [];
+  
+  // 이전 달의 날짜들 추가
+  for (let i = firstDayOfWeek - 1; i >= 0; i--) {
+    const date = prevMonthLastDay - i;
+    calendarDays.push({
+      date,
+      isCurrentMonth: false,
+      workoutColors: []
+    });
+  }
+  
+  // 현재 달의 날짜들 추가
+  for (let date = 1; date <= lastDay.getDate(); date++) {
+    const workoutData = calendarData.find(item => item.date === date);
+    calendarDays.push({
+      date,
+      isCurrentMonth: true,
+      workoutColors: workoutData ? workoutData.workoutColors : []
+    });
+  }
+  
+  // 다음 달의 날짜들 추가 (6주 완성)
+  const remainingDays = 42 - calendarDays.length;
+  for (let date = 1; date <= remainingDays; date++) {
+    calendarDays.push({
+      date,
+      isCurrentMonth: false,
+      workoutColors: []
+    });
+  }
+  
+  const weekDays = ['일', '월', '화', '수', '목', '금', '토'];
+
+  return (
+    <div className="w-full">
+      {/* 요일 헤더 */}
+      <div className="grid grid-cols-7 mb-1">
+        {weekDays.map((day) => (
+          <div key={day} className="text-center text-xs font-bold text-gray-600 py-2 border-gray-200">
+            {day}
+          </div>
+        ))}
+      </div>
+      
+      {/* 달력 그리드 */}
+      <div className="grid grid-cols-7 gap-0 border border-gray-200 rounded-lg overflow-hidden">
+        {calendarDays.map((day, index) => (
+          <CalendarDay
+            key={index}
+            date={day.date}
+            isCurrentMonth={day.isCurrentMonth}
+            workoutColors={day.workoutColors}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CalendarGrid;

--- a/src/pages/meeting/calendar/components/CalendarHeader.tsx
+++ b/src/pages/meeting/calendar/components/CalendarHeader.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+interface CalendarHeaderProps {
+  year: number;
+  month: number;
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+}
+
+const CalendarHeader: React.FC<CalendarHeaderProps> = ({
+  year,
+  month,
+  onPrevMonth,
+  onNextMonth
+}) => {
+  return (
+    <div className="w-full flex items-center justify-between mb-3">
+      {/* 이전/다음 월 버튼 */}
+      <button
+        onClick={onPrevMonth}
+        className="p-1 text-gray-600 hover:text-gray-800"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+      </button>
+      
+      {/* 년도와 월 */}
+      <h2 className="text-lg font-bold text-black">
+        {year} {month}월
+      </h2>
+      
+      {/* 다음 월 버튼 */}
+      <button
+        onClick={onNextMonth}
+        className="p-1 text-gray-600 hover:text-gray-800"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+export default CalendarHeader;

--- a/src/pages/meeting/calendar/components/MemberLegend.tsx
+++ b/src/pages/meeting/calendar/components/MemberLegend.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { MemberColor } from '../../../../types/meeting';
+
+interface MemberLegendProps {
+  memberColors: MemberColor[];
+}
+
+const MemberLegend: React.FC<MemberLegendProps> = ({ memberColors }) => {
+  return (
+    <div className="w-full">
+      <div className="grid grid-cols-3 gap-4">
+        {memberColors.map((member, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <div
+              className="w-2.5 h-2.5 rounded-full"
+              style={{ backgroundColor: member.color }}
+            ></div>
+            <span className="text-xs text-gray-700 truncate">{member.nickname}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MemberLegend;

--- a/src/pages/meeting/calendar/components/WorkoutDot.tsx
+++ b/src/pages/meeting/calendar/components/WorkoutDot.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface WorkoutDotProps {
+  color: string;
+}
+
+const WorkoutDot: React.FC<WorkoutDotProps> = ({ color }) => {
+  return (
+    <div
+      className="w-1.5 h-1.5 rounded-full"
+      style={{ backgroundColor: color }}
+    ></div>
+  );
+};
+
+export default WorkoutDot;

--- a/src/pages/meeting/index.tsx
+++ b/src/pages/meeting/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import MeetingTimer from './components/MeetingTimer';
-import MemberListPage from './MemberListPage';
-import CalendarPage from './CalendarPage';
+import MemberListPage from './memberList/MemberListPage';
+import CalendarPage from './calendar/CalendarPage';
 import ChallengePage from './ChallengePage';
 import RankingPage from './RankingPage';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -31,8 +31,8 @@ const MeetingPage: React.FC = () => {
         // 현재는 모의 데이터 사용
         const mockMeetingInfo: MeetingDetail = {
           id: '1',
-          name: '헬스 모임',
-          workoutType: '헬스',
+          name: '조깅 모임',
+          workoutType: '조깅',
           description: '매일 아침 조깅하는 모임입니다.',
           maxMembers: 10,
           memberCount: 5,

--- a/src/pages/meeting/memberList/MemberListPage.tsx
+++ b/src/pages/meeting/memberList/MemberListPage.tsx
@@ -1,14 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import type { MeetingMember } from '../../types/meeting';
-import meetingMembersData from '../../data/meetingMembers.json';
+import type { MeetingMember } from '../../../types/meeting';
+import meetingMembersData from '../../../data/meetingMembers.json';
 
 // 아이콘 imports
-import RunningActive from '../../assets/Running_active.svg';
-import RunningInactive from '../../assets/Running_inactive.svg';
-import CyclingActive from '../../assets/Cycling_active.svg';
-import CyclingInactive from '../../assets/Cycling_inactive.svg';
-import BarbellActive from '../../assets/Barbell_active.svg';
-import BarbellInactive from '../../assets/Barbell_inactive.svg';
+import RunningActive from '../../../assets/Running_active.svg';
+import RunningInactive from '../../../assets/Running_inactive.svg';
+import CyclingActive from '../../../assets/Cycling_active.svg';
+import CyclingInactive from '../../../assets/Cycling_inactive.svg';
+import BarbellActive from '../../../assets/Barbell_active.svg';
+import BarbellInactive from '../../../assets/Barbell_inactive.svg';
 
 interface MemberListPageProps {
   workoutType: string;

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -25,13 +25,9 @@ export interface MeetingDetail {
 }
 
 export interface WorkoutRecord {
-  id: string;
-  userId: string;
-  workoutType: string;
+  date: string; // YYYY-MM-DD 형식
+  memberId: string;
   workoutTime: number;
-  recorded_at: Date;
-  startTime: Date;
-  endTime: Date;
 }
 
 export interface MeetingMember {
@@ -39,4 +35,21 @@ export interface MeetingMember {
   nickname: string;
   todayWorkoutTime: number;
   isWorkingOut: boolean;
+}
+
+export interface CalendarData {
+  year: number;
+  month: number;
+  workoutRecords: WorkoutRecord[];
+  members: MeetingMember[];
+}
+
+export interface CalendarDayData {
+  date: number;
+  workoutColors: string[];
+}
+
+export interface MemberColor {
+  color: string;
+  nickname: string;
 }


### PR DESCRIPTION
## 연관 이슈
- #18 

---

## 작업 내용
- MeetingPage 내의 두번째 슬라이드 CalendarPage 레이아웃 구현
- API 연동 때의 편의를 위해 응답 객체, json파일 모의 데이터 생성 후 이를 이용해 구현

---

## 스크린 샷

https://github.com/user-attachments/assets/2190a094-f893-4e9f-8f9c-bafe6131ebd9

